### PR TITLE
Dockerfile and fix to join command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:argon
+
+# Update and install packages
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get -t jessie-backports install -y ffmpeg
+
+# Create local-music-bot directory
+RUN mkdir -p /usr/src/local-music-bot
+WORKDIR /usr/src/local-music-bot
+
+# Install app dependencies
+COPY package.json /usr/src/local-music-bot/
+RUN npm install
+
+# Bundle local-music-bot source
+COPY . /usr/src/local-music-bot
+
+CMD [ "npm", "start" ]

--- a/commands/join.js
+++ b/commands/join.js
@@ -10,7 +10,7 @@ exports.execute = function (data, cm) {
         if (!cm.bot.voiceConnection) {
             const check = new RegExp(`.*${data.args}.*`, 'i');
 
-            for (const channel of data.m.channel.server.channels) {
+            for (const channel of data.m.channel.server.channels.getAll('type', 'voice')) {
                 if (channel.name.search(check) !== -1) {
                     cm.bot.joinVoiceChannel(channel);
                     break;


### PR DESCRIPTION
Added Dockerfile for use with Docker and updated the join command to only look at voice channels. This fixes an issue where a text channel may have a similar name to the voice channel and the bot fail to join the correct one.
